### PR TITLE
attempt to remove meta-call related noise from ntimes/2 loop

### DIFF
--- a/run.pl
+++ b/run.pl
@@ -164,7 +164,7 @@ ntimes(M, N, T, GC):-
 	get_performance_stats(GC0, T0),
 	ntimes(Goal, N),
 	get_performance_stats(GC1, T1),
-	ntimes_dummy(N),
+	ntimes(dummy, N),
 	get_performance_stats(GC2, T2),
 	T  is (T1-T0) - (T2-T1),
 	GC is (GC1-GC0) - (GC2-GC1).
@@ -176,22 +176,17 @@ top(M, Goal) :-
 top(M, M:top).
 :- endif.
 
+:- if(current_prolog_flag(dialect, ciao)).
+:- meta_predicate ntimes(goal,?).
+:- endif.
+
 ntimes(_, N) :- N=:=0, !.
 ntimes(M, N) :- not_not_top(M), !, N1 is N-1, ntimes(M, N1).
-
-ntimes_dummy(N) :- N=:=0, !.
-ntimes_dummy(N) :- not_not_dummy, !, N1 is N-1, ntimes_dummy(N1).
 
 not_not_top(M) :- not_top(M), !, fail.
 not_not_top(_).
 
 not_top(Goal) :- call(Goal), !, fail.
 not_top(_).
-
-not_not_dummy :- not_dummy, !, fail.
-not_not_dummy.
-
-not_dummy :- dummy, !, fail.
-not_dummy.
 
 dummy.


### PR DESCRIPTION
This commit removes some noise due to meta-calls in ntimes/2 loop:
 - replace ntimes_dummy(N) by ntimes(dummy,N) so that we measure the time spent in call/1 properly
 - add `meta_predicate` for the ntimes/2 predicate in Ciao